### PR TITLE
Add warnings for Python missing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,38 @@ For a Python requirements.txt file:
 python main.py --python [filename]
 ```
 
+Example command using deps2repos's own requirements.txt as input.
+
+```
+python main.py --python requirements.txt
+```
+
+Example output:
+
+```
+WARNING: Some of the packages found on PyPI do not have GitHubs:
+pkginfo
+
+https://github.com/c0fec0de/anytree
+https://github.com/benjaminp/six
+https://github.com/certifi/python-certifi
+https://github.com/ousret/charset_normalizer
+https://github.com/pallets/click
+https://github.com/python/importlib_metadata
+https://github.com/python/typing
+https://github.com/jaraco/zipp
+https://github.com/kjd/idna
+https://github.com/pypa/packaging
+https://github.com/pyparsing/pyparsing
+https://github.com/pypa/pip
+https://github.com/ddelange/pipgrip
+https://github.com/pypa/setuptools
+https://github.com/pypa/wheel
+https://github.com/psf/requests
+https://github.com/urllib3/urllib3
+https://github.com/davidfischer/requirements-parser
+```
+
 ## Run Tests
 
 ```

--- a/main.py
+++ b/main.py
@@ -2,12 +2,7 @@
 
 import argparse
 
-from pypi import (
-    get_github_url_from_pypi_json,
-    get_pypi_data_json,
-    get_pypi_package_dependencies,
-    parse_requirements_dot_text,
-)
+from pypi import python_requirements_dot_text_analysis
 
 
 def parse_command_line_arguments():
@@ -30,25 +25,4 @@ if __name__ == "__main__":
     # parse specified Python requirements.txt file and generate GitHub links
     # for all top-level AND transitive dependencies.
     if args.python:
-
-        top_level_pkgs = parse_requirements_dot_text(args.python)
-
-        # Retrieve all dependencies, both top-level and transitive, and keep a
-        # unique list
-        all_pkgs = []
-        for pkg in top_level_pkgs:
-            all_deps = get_pypi_package_dependencies(pkg)
-            for dep in all_deps:
-                if dep not in all_pkgs:
-                    all_pkgs.append(dep)
-
-        # retrieve github urls for unique pypi packages
-        github_urls = []
-        for pkg in all_pkgs:
-            pypi_json = get_pypi_data_json(pkg)
-            github_url = get_github_url_from_pypi_json(pypi_json)
-            if github_url:
-                github_urls.append(github_url)
-
-        for url in github_urls:
-            print(url)
+        python_requirements_dot_text_analysis(args.python)


### PR DESCRIPTION
Following George's critique, provide information to user when using PyPI/requirements.txt functionality on when packages are not in PyPI or GitHub links are not found on the PyPI page.